### PR TITLE
Material style sidebar layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-# pebble-expense-tracker
+# No BS Money Tracker
+
+This is a super lightweight expense tracker built with plain HTML, CSS and JavaScript.
+The UI now uses a Material 3 inspired design with a sidebar containing Home, Categories and Settings options.
+Use the floating "+" button in the bottom right corner to quickly add an expense.
+All data is stored in your browser using `localStorage` so it works completely offline.
+
+Open `index.html` in your browser to start using it. No build step or dependencies are required.

--- a/add.html
+++ b/add.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Add Expense</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="layout">
+    <nav class="sidebar">
+      <h2>No BS</h2>
+      <a href="index.html">Home</a>
+      <a href="categories.html">Categories</a>
+      <a href="settings.html">Settings</a>
+    </nav>
+    <main>
+      <h1>Add Expense</h1>
+      <form id="expense-form">
+        <input type="number" id="amount" placeholder="Amount" required>
+        <select id="category">
+          <option>Food</option>
+          <option>Transport</option>
+          <option>Shopping</option>
+          <option>Other</option>
+        </select>
+        <input type="text" id="note" placeholder="Note (optional)">
+        <input type="date" id="date">
+        <button type="submit" class="button">Save</button>
+      </form>
+    </main>
+  </div>
+  <script src="add.js"></script>
+</body>
+</html>

--- a/add.js
+++ b/add.js
@@ -1,0 +1,28 @@
+function getExpenses() {
+  try {
+    return JSON.parse(localStorage.getItem('expenses') || '[]');
+  } catch {
+    return [];
+  }
+}
+
+function saveExpense(e) {
+  e.preventDefault();
+  const amount = parseFloat(document.getElementById('amount').value);
+  if (isNaN(amount)) return;
+  const category = document.getElementById('category').value;
+  const note = document.getElementById('note').value;
+  const date = document.getElementById('date').value || new Date().toISOString().slice(0,10);
+  const expenses = getExpenses();
+  expenses.push({ id: Date.now().toString(), amount, category, note, date });
+  localStorage.setItem('expenses', JSON.stringify(expenses));
+  window.location.href = 'index.html';
+}
+
+document.getElementById('expense-form').addEventListener('submit', saveExpense);
+
+// default date to today
+const dateInput = document.getElementById('date');
+if (dateInput) {
+  dateInput.value = new Date().toISOString().slice(0,10);
+}

--- a/categories.html
+++ b/categories.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Categories</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="layout">
+    <nav class="sidebar">
+      <h2>No BS</h2>
+      <a href="index.html">Home</a>
+      <a href="categories.html">Categories</a>
+      <a href="settings.html">Settings</a>
+    </nav>
+    <main>
+      <h1>Categories</h1>
+      <p>Manage your expense categories here.</p>
+    </main>
+  </div>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>No BS Money Tracker</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="layout">
+    <nav class="sidebar">
+      <h2>No BS</h2>
+      <a href="index.html">Home</a>
+      <a href="categories.html">Categories</a>
+      <a href="settings.html">Settings</a>
+    </nav>
+    <main>
+      <h1>Remaining Budget</h1>
+      <div id="total" class="big"></div>
+      <ul id="list"></ul>
+    </main>
+    <a href="add.html" class="fab">+</a>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,24 @@
+function getExpenses() {
+  try {
+    return JSON.parse(localStorage.getItem('expenses') || '[]');
+  } catch {
+    return [];
+  }
+}
+
+function showExpenses() {
+  const list = document.getElementById('list');
+  const totalEl = document.getElementById('total');
+  const expenses = getExpenses();
+  let total = 0;
+  list.innerHTML = '';
+  expenses.slice().reverse().forEach(e => {
+    total += e.amount;
+    const li = document.createElement('li');
+    li.innerHTML = `<span>${e.category}</span><span>₹${e.amount.toFixed(2)}</span>`;
+    list.appendChild(li);
+  });
+  totalEl.textContent = `₹${total.toFixed(2)}`;
+}
+
+document.addEventListener('DOMContentLoaded', showExpenses);

--- a/settings.html
+++ b/settings.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Settings</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="layout">
+    <nav class="sidebar">
+      <h2>No BS</h2>
+      <a href="index.html">Home</a>
+      <a href="categories.html">Categories</a>
+      <a href="settings.html">Settings</a>
+    </nav>
+    <main>
+      <h1>Settings</h1>
+      <p>App settings will appear here.</p>
+    </main>
+  </div>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,115 @@
+:root {
+  --md-primary: #6750a4;
+  --md-on-primary: #ffffff;
+  --md-surface: #fef7ff;
+  --md-on-surface: #1c1b1f;
+  --md-surface-variant: #e7e0ec;
+}
+
+body {
+  margin: 0;
+  font-family: Arial, Helvetica, sans-serif;
+  background: var(--md-surface);
+  color: var(--md-on-surface);
+}
+
+.layout {
+  display: flex;
+  min-height: 100vh;
+}
+
+.sidebar {
+  width: 200px;
+  background: var(--md-surface-variant);
+  padding: 1rem;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+}
+
+.sidebar h2 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+.sidebar a {
+  text-decoration: none;
+  color: var(--md-on-surface);
+  padding: 0.75rem 1rem;
+  border-radius: 24px;
+  margin-bottom: 0.25rem;
+  display: block;
+}
+
+.sidebar a:hover {
+  background: var(--md-primary);
+  color: var(--md-on-primary);
+}
+
+main {
+  flex: 1;
+  padding: 1rem;
+  max-width: 600px;
+}
+
+.big {
+  font-size: 2.5rem;
+  font-weight: bold;
+  margin: 1rem 0;
+}
+
+.button {
+  display: inline-block;
+  background: var(--md-primary);
+  color: var(--md-on-primary);
+  padding: 0.75rem 1.25rem;
+  border-radius: 24px;
+  text-decoration: none;
+  border: none;
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+input, select {
+  padding: 0.75rem;
+  font-size: 1rem;
+  border: 1px solid var(--md-surface-variant);
+  border-radius: 8px;
+  background: #fff;
+}
+
+ul {
+  list-style: none;
+  padding: 0;
+}
+
+li {
+  display: flex;
+  justify-content: space-between;
+  background: #fff;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+  margin-bottom: 0.5rem;
+}
+
+.fab {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: var(--md-primary);
+  color: var(--md-on-primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  text-decoration: none;
+  box-shadow: 0 4px 6px rgba(0,0,0,0.3);
+}


### PR DESCRIPTION
## Summary
- revamp UI with a Material 3 inspired look
- add a left sidebar with Home, Categories, and Settings links
- apply Material color scheme and card styles
- create placeholder pages for categories and settings
- add floating action button for quick expense entry

## Testing
- No build or lint steps – open `index.html` in the browser

------
https://chatgpt.com/codex/tasks/task_e_686cae799cb083278e3e6f7a97208932