### PR TITLE
Add searchable currency dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# No BS Money Tracker
+# Pebble Expense Tracker
 
 This is a super lightweight expense tracker built with plain HTML, CSS and JavaScript.
-The UI now uses a Material 3 inspired design with a sidebar containing Home, Categories and Settings options.
+The UI now uses a Material 3 inspired design with a sidebar containing Home, Categories and Settings options. The sidebar shows icons next to each page link and highlights the page you're viewing.
 Click the floating "+" button in the bottom right corner to expand a colored pop-up form and add an expense without leaving the page. The amount field is focused automatically for speedy entry and you can move through the form with the down arrow key. Tap the date button to smoothly expand an inline calendar. After choosing a day, the calendar collapses back into the button. Tap the category button to reveal a grid of chips for quick selection. Use the close icon or press Esc to dismiss the form.
-All data is stored in your browser using `localStorage` so it works completely offline.
+All data is stored in your browser using `localStorage` so it works completely offline. You can also choose which currency symbol is used on the website from the Settings page with a searchable dropdown.
 
 Open `index.html` in your browser to start using it. No build step or dependencies are required.

--- a/add.html
+++ b/add.html
@@ -9,10 +9,10 @@
 <body>
   <div class="layout">
     <nav class="sidebar">
-      <h2>No BS</h2>
-      <a href="index.html">Home</a>
-      <a href="categories.html">Categories</a>
-      <a href="settings.html">Settings</a>
+      <h2>Pebble</h2>
+      <a href="index.html" class="active"><span class="icon">🏠</span>Home</a>
+      <a href="categories.html"><span class="icon">📂</span>Categories</a>
+      <a href="settings.html"><span class="icon">⚙️</span>Settings</a>
     </nav>
     <main>
       <h1>Add Expense</h1>

--- a/categories.html
+++ b/categories.html
@@ -9,10 +9,10 @@
 <body>
   <div class="layout">
     <nav class="sidebar">
-      <h2>No BS</h2>
-      <a href="index.html">Home</a>
-      <a href="categories.html">Categories</a>
-      <a href="settings.html">Settings</a>
+      <h2>Pebble</h2>
+      <a href="index.html"><span class="icon">🏠</span>Home</a>
+      <a href="categories.html" class="active"><span class="icon">📂</span>Categories</a>
+      <a href="settings.html"><span class="icon">⚙️</span>Settings</a>
     </nav>
     <main>
       <h1>Categories</h1>

--- a/index.html
+++ b/index.html
@@ -3,16 +3,16 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>No BS Money Tracker</title>
+  <title>Pebble Expense Tracker</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <div class="layout">
     <nav class="sidebar">
-      <h2>No BS</h2>
-      <a href="index.html">Home</a>
-      <a href="categories.html">Categories</a>
-      <a href="settings.html">Settings</a>
+      <h2>Pebble</h2>
+      <a href="index.html" class="active"><span class="icon">🏠</span>Home</a>
+      <a href="categories.html"><span class="icon">📂</span>Categories</a>
+      <a href="settings.html"><span class="icon">⚙️</span>Settings</a>
     </nav>
     <main>
       <h1>Remaining Budget</h1>

--- a/settings.html
+++ b/settings.html
@@ -9,15 +9,26 @@
 <body>
   <div class="layout">
     <nav class="sidebar">
-      <h2>No BS</h2>
-      <a href="index.html">Home</a>
-      <a href="categories.html">Categories</a>
-      <a href="settings.html">Settings</a>
+      <h2>Pebble</h2>
+      <a href="index.html"><span class="icon">🏠</span>Home</a>
+      <a href="categories.html"><span class="icon">📂</span>Categories</a>
+      <a href="settings.html" class="active"><span class="icon">⚙️</span>Settings</a>
     </nav>
     <main>
       <h1>Settings</h1>
-      <p>App settings will appear here.</p>
+      <form id="settings-form" class="settings-form">
+        <label for="currency-btn">Currency</label>
+        <div class="currency-select">
+          <button type="button" id="currency-btn" class="select-btn"></button>
+          <div id="currency-menu" class="currency-menu" hidden>
+            <input type="text" id="currency-search" class="search-input" placeholder="Search currency">
+            <div id="currency-options" class="options"></div>
+          </div>
+        </div>
+        <button type="submit" id="settings-save" class="button">Save <span id="save-icon" class="save-icon"></span></button>
+      </form>
     </main>
   </div>
+  <script src="script.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -42,12 +42,20 @@ body {
   padding: 0.75rem 1rem;
   border-radius: 24px;
   margin-bottom: 0.25rem;
-  display: block;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
-.sidebar a:hover {
+.sidebar a:hover,
+.sidebar a.active {
   background: var(--md-primary);
   color: var(--md-on-primary);
+}
+
+.sidebar a .icon {
+  width: 1.25em;
+  text-align: center;
 }
 
 main {
@@ -299,4 +307,90 @@ input[type=number]::-webkit-inner-spin-button {
 }
 input[type=number] {
   -moz-appearance: textfield;
+}
+
+.settings-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-width: 300px;
+  margin: 0 auto;
+}
+
+.settings-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.currency-select {
+  position: relative;
+}
+
+.currency-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  background: var(--md-surface);
+  border: 1px solid var(--md-surface-variant);
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+  padding: 0.5rem;
+  width: 100%;
+  max-height: 250px;
+  overflow-y: auto;
+  z-index: 5;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  box-sizing: border-box;
+}
+
+.search-input {
+  padding: 0.5rem;
+  border: 1px solid var(--md-surface-variant);
+  border-radius: 6px;
+  margin-bottom: 0.5rem;
+}
+
+.currency-option {
+  padding: 0.25rem 0.5rem;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.currency-option:hover,
+.currency-option.selected {
+  background: var(--md-primary);
+  color: var(--md-on-primary);
+}
+
+#settings-save {
+  position: fixed;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.save-icon {
+  display: inline-block;
+  margin-left: 0.5rem;
+  vertical-align: middle;
+  width: 1em;
+  height: 1em;
+}
+
+.save-icon.loading {
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+.save-icon.check {
+  font-weight: bold;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
 }


### PR DESCRIPTION
## Summary
- replace `<select>` currency field with a custom dropdown that allows searching
- center the Save button at the bottom and show spinner/check animation on save
- keep selected currency symbol across the app
- document the searchable Settings dropdown in README
- rebrand sidebar as **Pebble** and highlight the active page with icons

## Testing
- `node -e "console.log(Intl.supportedValuesOf('currency').slice(0,3))"`


------
https://chatgpt.com/codex/tasks/task_e_686e9788d87c832788abe8d79bf5e1d8