### PR TITLE
Fix expanded sidebar width and color

### DIFF
--- a/script.js
+++ b/script.js
@@ -224,16 +224,12 @@ function initSettings() {
     e.preventDefault();
     localStorage.setItem('currencySymbol', selected);
     if (saveIcon) {
-      saveIcon.textContent = '';
-      saveIcon.className = 'save-icon loading';
+      saveIcon.textContent = '✔';
+      saveIcon.className = 'save-icon show';
       setTimeout(() => {
-        saveIcon.className = 'save-icon check';
-        saveIcon.textContent = '✔';
-        setTimeout(() => {
-          saveIcon.className = 'save-icon';
-          saveIcon.textContent = '';
-        }, 1500);
-      }, 800);
+        saveIcon.className = 'save-icon';
+        saveIcon.textContent = '';
+      }, 1000);
     }
     showExpenses();
   });

--- a/style.css
+++ b/style.css
@@ -30,12 +30,23 @@ body {
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  transition: width 0.3s ease, background 0.3s ease;
+  transition: width 0.3s ease, background 0.3s ease, color 0.3s ease;
 }
 
 .sidebar.expanded {
   width: 33%;
-  background: var(--md-sidebar-light);
+  background: var(--md-primary);
+  color: var(--md-on-primary);
+}
+
+.sidebar.expanded a {
+  color: var(--md-on-primary);
+}
+
+.sidebar.expanded a:hover,
+.sidebar.expanded a.active {
+  background: var(--md-on-primary);
+  color: var(--md-primary);
 }
 
 .sidebar.show-page .nav-top {
@@ -58,6 +69,7 @@ body {
 
 .sidebar.expanded .close-sidebar {
   display: block;
+  color: var(--md-on-primary);
 }
 
 .sidebar-page h1 {
@@ -84,6 +96,8 @@ body {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .sidebar a:hover,
@@ -369,8 +383,7 @@ input[type=number] {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  max-width: 300px;
-  margin: 0 auto;
+  width: 100%;
   flex: 1;
 }
 
@@ -423,8 +436,11 @@ input[type=number] {
 }
 
 #settings-save {
-  align-self: center;
+  align-self: stretch;
   margin-top: auto;
+  width: 100%;
+  background: var(--md-on-primary);
+  color: var(--md-primary);
 }
 
 .save-icon {
@@ -433,19 +449,12 @@ input[type=number] {
   vertical-align: middle;
   width: 1em;
   height: 1em;
+  opacity: 0;
+  transform: scale(0.5);
+  transition: opacity 0.3s ease, transform 0.3s ease;
 }
 
-.save-icon.loading {
-  border: 2px solid currentColor;
-  border-top-color: transparent;
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-}
-
-.save-icon.check {
-  font-weight: bold;
-}
-
-@keyframes spin {
-  to { transform: rotate(360deg); }
+.save-icon.show {
+  opacity: 1;
+  transform: scale(1);
 }


### PR DESCRIPTION
## Summary
- style sidebar links to take full width
- remove settings form width limit
- color expanded sidebar the same as the add button
- restyle settings save button and simplify animation

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6870f596a830832797eeb5583e7eebed