### PR TITLE
Improve edit popup styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,11 +19,19 @@
       <div id="sidebar-content" class="sidebar-content"></div>
     </nav>
     <main>
-      <div class="today-summary">
-        <small class="today-label">Spent Today</small>
-        <div id="total" class="today-amount"></div>
+      <div class="home-grid">
+        <div class="today-summary grid-item">
+          <small class="today-label">Spent Today</small>
+          <div id="total" class="today-amount"></div>
+        </div>
+        <section id="transactions-section" class="transactions-section grid-item">
+          <div class="trans-header">
+            <h2>Transactions</h2>
+            <button type="button" id="view-all" class="view-all">View all transactions</button>
+          </div>
+          <div id="transactions-list"></div>
+        </section>
       </div>
-      <ul id="list"></ul>
     </main>
     <div class="fab-wrapper">
       <button id="fab" class="fab">+</button>

--- a/script.js
+++ b/script.js
@@ -27,6 +27,7 @@ function getSymbolFromCode(code) {
 let selectedDate = new Date();
 let currentCalMonth = new Date();
 let selectedCategory = 'Food';
+let viewAll = false;
 
 function resetForm() {
   const amount = document.getElementById('amount');
@@ -101,27 +102,207 @@ function toggleCalendar(forceOpen) {
   }
 }
 
+function createExpenseItem(e, symbol) {
+  const li = document.createElement('li');
+  li.className = 'expense-item';
+  li.dataset.id = e.id;
+
+  const summary = document.createElement('div');
+  summary.className = 'item-summary';
+  summary.innerHTML = `<span>${e.category}</span><span>${symbol}${e.amount.toFixed(2)}</span>`;
+  li.appendChild(summary);
+
+  const details = document.createElement('div');
+  details.className = 'item-details';
+  details.innerHTML = `
+    <div class="form-fields">
+      <input type="number" class="edit-amount" value="${e.amount}">
+      <div class="category-select">
+        <button type="button" class="edit-cat-btn select-btn">${e.category}</button>
+        <div class="chip-menu edit-cat-menu" hidden>
+          <button type="button" class="chip" data-value="Food">Food</button>
+          <button type="button" class="chip" data-value="Transport">Transport</button>
+          <button type="button" class="chip" data-value="Shopping">Shopping</button>
+          <button type="button" class="chip" data-value="Other">Other</button>
+        </div>
+      </div>
+      <input type="text" class="edit-note" placeholder="Note" value="${e.note || ''}">
+      <button type="button" class="edit-date-btn calendar-btn">📅 <span class="edit-date-display"></span></button>
+      <div class="calendar-view edit-cal-view">
+        <div class="calendar-header">
+          <button type="button" class="cal-nav edit-prev-month">‹</button>
+          <span class="edit-cal-month"></span>
+          <button type="button" class="cal-nav edit-next-month">›</button>
+        </div>
+        <div class="calendar-grid edit-cal-grid"></div>
+      </div>
+      <div class="actions">
+        <button type="button" class="delete-btn">Delete</button>
+        <button type="button" class="save-btn">Save</button>
+      </div>
+    </div>`;
+  li.appendChild(details);
+
+  summary.addEventListener('click', () => {
+    document.querySelectorAll('.expense-item.expanded').forEach(other => {
+      if (other !== li) other.classList.remove('expanded');
+    });
+    li.classList.toggle('expanded');
+  });
+
+  initEditItem(li, e);
+  return li;
+}
+
 function showExpenses() {
-  const list = document.getElementById('list');
+  const container = document.getElementById('transactions-list');
   const totalEl = document.getElementById('total');
-  if (!list || !totalEl) return;
+  if (!container || !totalEl) return;
   const expenses = getExpenses();
   const symbol = getCurrency();
   let todayTotal = 0;
   const today = new Date().toLocaleDateString('en-CA');
-  list.innerHTML = '';
-  expenses
-    .slice()
-    .sort((a, b) => new Date(b.date) - new Date(a.date))
-    .forEach(e => {
-      if (e.date === today) {
-        todayTotal += e.amount;
-      }
-      const li = document.createElement('li');
-      li.innerHTML = `<span>${e.date} - ${e.category}</span><span>${symbol}${e.amount.toFixed(2)}</span>`;
-      list.appendChild(li);
+  container.innerHTML = '';
+
+  const sorted = expenses.slice().sort((a, b) => new Date(b.date) - new Date(a.date));
+
+  if (viewAll) {
+    const grouped = {};
+    sorted.forEach(e => {
+      if (!grouped[e.date]) grouped[e.date] = [];
+      grouped[e.date].push(e);
+      if (e.date === today) todayTotal += e.amount;
     });
+    Object.keys(grouped)
+      .sort((a, b) => new Date(b) - new Date(a))
+      .forEach(date => {
+        const card = document.createElement('div');
+        card.className = 'date-card';
+        const header = document.createElement('div');
+        header.className = 'date-header';
+        header.textContent = date;
+        const ul = document.createElement('ul');
+        ul.className = 'date-list';
+        grouped[date].forEach(exp => ul.appendChild(createExpenseItem(exp, symbol)));
+        card.appendChild(header);
+        card.appendChild(ul);
+        container.appendChild(card);
+      });
+  } else {
+    sorted.forEach(e => {
+      if (e.date !== today) return;
+      todayTotal += e.amount;
+      container.appendChild(createExpenseItem(e, symbol));
+    });
+  }
+
   totalEl.textContent = `${symbol}${todayTotal.toFixed(2)}`;
+}
+
+function updateExpense(id, amount, category, note, date) {
+  const expenses = getExpenses();
+  const idx = expenses.findIndex(e => e.id === id);
+  if (idx === -1) return;
+  if (!isNaN(amount)) expenses[idx].amount = amount;
+  expenses[idx].category = category;
+  expenses[idx].note = note;
+  expenses[idx].date = date;
+  localStorage.setItem('expenses', JSON.stringify(expenses));
+  showExpenses();
+}
+
+function deleteExpense(id) {
+  const expenses = getExpenses().filter(e => e.id !== id);
+  localStorage.setItem('expenses', JSON.stringify(expenses));
+  showExpenses();
+}
+
+function initEditItem(li, expense) {
+  const details = li.querySelector('.item-details');
+  if (!details) return;
+
+  const amountInput = details.querySelector('.edit-amount');
+  const noteInput = details.querySelector('.edit-note');
+  const catBtn = details.querySelector('.edit-cat-btn');
+  const catMenu = details.querySelector('.edit-cat-menu');
+  const calendarBtn = details.querySelector('.edit-date-btn');
+  const calendarView = details.querySelector('.edit-cal-view');
+  const calMonth = details.querySelector('.edit-cal-month');
+  const calGrid = details.querySelector('.edit-cal-grid');
+  const prevMonth = details.querySelector('.edit-prev-month');
+  const nextMonth = details.querySelector('.edit-next-month');
+
+  let selectedDate = new Date(expense.date);
+  let currentMonth = new Date(selectedDate);
+
+  function updateDateDisplay() {
+    const span = calendarBtn.querySelector('.edit-date-display');
+    if (span) span.textContent = selectedDate.toLocaleDateString('en-CA');
+  }
+
+  function buildCal() {
+    calGrid.innerHTML = '';
+    const year = currentMonth.getFullYear();
+    const month = currentMonth.getMonth();
+    calMonth.textContent = currentMonth.toLocaleString('default', { month: 'long', year: 'numeric' });
+    const firstDay = new Date(year, month, 1).getDay();
+    const daysInMonth = new Date(year, month + 1, 0).getDate();
+    for (let i = 0; i < firstDay; i++) {
+      calGrid.appendChild(document.createElement('div'));
+    }
+    for (let d = 1; d <= daysInMonth; d++) {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.textContent = d;
+      btn.className = 'calendar-day';
+      if (year === selectedDate.getFullYear() && month === selectedDate.getMonth() && d === selectedDate.getDate()) {
+        btn.classList.add('selected');
+      }
+      btn.addEventListener('click', () => {
+        selectedDate = new Date(year, month, d);
+        calendarView.classList.remove('open');
+        updateDateDisplay();
+      });
+      calGrid.appendChild(btn);
+    }
+  }
+
+  calendarBtn.addEventListener('click', () => {
+    const open = calendarView.classList.contains('open');
+    calendarView.classList.toggle('open', !open);
+    if (!open) {
+      currentMonth = new Date(selectedDate);
+      buildCal();
+    }
+  });
+  prevMonth.addEventListener('click', () => { currentMonth.setMonth(currentMonth.getMonth() - 1); buildCal(); });
+  nextMonth.addEventListener('click', () => { currentMonth.setMonth(currentMonth.getMonth() + 1); buildCal(); });
+
+  updateDateDisplay();
+
+  catBtn.addEventListener('click', () => { catMenu.hidden = !catMenu.hidden; });
+  catMenu.querySelectorAll('.chip').forEach(chip => {
+    chip.addEventListener('click', () => {
+      catBtn.textContent = chip.dataset.value;
+      catMenu.hidden = true;
+    });
+  });
+  document.addEventListener('click', e => {
+    if (!catBtn.contains(e.target) && !catMenu.contains(e.target)) {
+      catMenu.hidden = true;
+    }
+  });
+
+  const delBtn = details.querySelector('.delete-btn');
+  const saveBtn = details.querySelector('.save-btn');
+  delBtn.addEventListener('click', () => deleteExpense(expense.id));
+  saveBtn.addEventListener('click', () => {
+    const newAmount = parseFloat(amountInput.value);
+    const newCat = catBtn.textContent.trim() || expense.category;
+    const newDate = selectedDate.toLocaleDateString('en-CA');
+    const newNote = noteInput.value;
+    updateExpense(expense.id, newAmount, newCat, newNote, newDate);
+  });
 }
 
 function saveExpense(e) {
@@ -224,16 +405,12 @@ function initSettings() {
     e.preventDefault();
     localStorage.setItem('currencySymbol', selected);
     if (saveIcon) {
-      saveIcon.textContent = '';
-      saveIcon.className = 'save-icon loading';
+      saveIcon.textContent = '✔';
+      saveIcon.className = 'save-icon show';
       setTimeout(() => {
-        saveIcon.className = 'save-icon check';
-        saveIcon.textContent = '✔';
-        setTimeout(() => {
-          saveIcon.className = 'save-icon';
-          saveIcon.textContent = '';
-        }, 1500);
-      }, 800);
+        saveIcon.className = 'save-icon';
+        saveIcon.textContent = '';
+      }, 1000);
     }
     showExpenses();
   });
@@ -315,6 +492,17 @@ function init() {
       if (!catBtn.contains(e.target) && !menu.contains(e.target)) {
         menu.hidden = true;
       }
+    });
+  }
+
+  const viewBtn = document.getElementById('view-all');
+  const transSection = document.getElementById('transactions-section');
+  if (viewBtn && transSection) {
+    viewBtn.addEventListener('click', () => {
+      viewAll = !viewAll;
+      transSection.classList.toggle('expanded', viewAll);
+      viewBtn.textContent = viewAll ? 'Collapse' : 'View all transactions';
+      showExpenses();
     });
   }
 

--- a/style.css
+++ b/style.css
@@ -30,12 +30,23 @@ body {
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  transition: width 0.3s ease, background 0.3s ease;
+  transition: width 0.3s ease, background 0.3s ease, color 0.3s ease;
 }
 
 .sidebar.expanded {
   width: 33%;
-  background: var(--md-sidebar-light);
+  background: var(--md-primary);
+  color: var(--md-on-primary);
+}
+
+.sidebar.expanded a {
+  color: var(--md-on-primary);
+}
+
+.sidebar.expanded a:hover,
+.sidebar.expanded a.active {
+  background: var(--md-on-primary);
+  color: var(--md-primary);
 }
 
 .sidebar.show-page .nav-top {
@@ -58,6 +69,7 @@ body {
 
 .sidebar.expanded .close-sidebar {
   display: block;
+  color: var(--md-on-primary);
 }
 
 .sidebar-page h1 {
@@ -84,6 +96,8 @@ body {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .sidebar a:hover,
@@ -106,7 +120,69 @@ body {
 main {
   flex: 1;
   padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+main > * {
+  width: 100%;
   max-width: 600px;
+}
+
+.home-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1rem;
+  width: 100%;
+  align-items: start;
+}
+
+.today-summary.grid-item {
+  grid-column: span 2;
+}
+
+.transactions-section {
+  width: 100%;
+  max-width: 600px;
+}
+
+.transactions-section.expanded {
+  max-width: none;
+  width: 100%;
+}
+
+.trans-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.view-all {
+  background: transparent;
+  border: none;
+  color: var(--md-primary);
+  cursor: pointer;
+}
+
+.date-card {
+  background: #fff;
+  border-radius: 12px;
+  padding: 0.5rem 1rem 1rem;
+  margin-bottom: 1rem;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+}
+
+.date-header {
+  font-weight: bold;
+  margin-bottom: 0.25rem;
+}
+
+.date-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
 }
 
 .big {
@@ -117,13 +193,16 @@ main {
 
 .today-summary {
   text-align: center;
-  margin-top: 1rem;
+  margin: 2rem auto 1rem;
+  min-width: 33%;
+  width: fit-content;
 }
 
 .today-amount {
-  font-size: 3.5rem;
+  font-size: 4rem;
   font-weight: bold;
   margin: 0.25rem 0 1.5rem;
+  overflow-wrap: anywhere;
 }
 
 .button {
@@ -160,14 +239,86 @@ ul {
   padding: 0;
 }
 
+#transactions-list {
+  width: 100%;
+  max-width: 600px;
+  margin-left: 0;
+  align-self: flex-start;
+}
+
 li {
-  display: flex;
-  justify-content: space-between;
+  display: block;
   background: #fff;
   padding: 0.75rem 1rem;
   border-radius: 12px;
   box-shadow: 0 1px 3px rgba(0,0,0,0.1);
   margin-bottom: 0.5rem;
+  overflow: hidden;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+li.expanded {
+  background: var(--md-primary);
+  color: var(--md-on-primary);
+}
+
+li.expanded .item-summary {
+  display: none;
+}
+
+.item-summary {
+  display: flex;
+  justify-content: space-between;
+  cursor: pointer;
+}
+
+.item-details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0;
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.4s ease, padding 0.3s ease, margin-top 0.3s ease;
+  background: transparent;
+  color: inherit;
+  padding: 0 1rem;
+}
+
+li.expanded .item-details {
+  max-height: 500px;
+  padding: 1rem;
+  margin-top: 0.5rem;
+}
+
+.item-details .actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.delete-btn {
+  background: #d32f2f;
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.save-btn {
+  background: var(--md-primary);
+  color: var(--md-on-primary);
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.item-details input,
+.item-details .select-btn,
+.item-details .calendar-btn {
+  background: var(--md-on-primary);
+  color: var(--md-primary);
 }
 
 .fab-wrapper {
@@ -369,8 +520,7 @@ input[type=number] {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  max-width: 300px;
-  margin: 0 auto;
+  width: 100%;
   flex: 1;
 }
 
@@ -423,8 +573,11 @@ input[type=number] {
 }
 
 #settings-save {
-  align-self: center;
+  align-self: stretch;
   margin-top: auto;
+  width: 100%;
+  background: var(--md-on-primary);
+  color: var(--md-primary);
 }
 
 .save-icon {
@@ -433,19 +586,12 @@ input[type=number] {
   vertical-align: middle;
   width: 1em;
   height: 1em;
+  opacity: 0;
+  transform: scale(0.5);
+  transition: opacity 0.3s ease, transform 0.3s ease;
 }
 
-.save-icon.loading {
-  border: 2px solid currentColor;
-  border-top-color: transparent;
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-}
-
-.save-icon.check {
-  font-weight: bold;
-}
-
-@keyframes spin {
-  to { transform: rotate(360deg); }
+.save-icon.show {
+  opacity: 1;
+  transform: scale(1);
 }


### PR DESCRIPTION
## Summary
- style expanded expense details like the add popup
- allow choosing category and date when editing
- expanded transaction card now changes to edit mode with purple background
- redesign home page grid and add view-all transactions mode

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6870f596a830832797eeb5583e7eebed