### PR TITLE
Add React widgets and masonry layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,81 @@
+const e = React.createElement;
+const { useState, useEffect } = React;
+
+function WidgetCard({ children }) {
+  return e('div', { className: 'widget-card' }, children);
+}
+
+function SpentTodayWidget() {
+  const [total, setTotal] = useState(0);
+  useEffect(() => {
+    function calc() {
+      const today = new Date().toLocaleDateString('en-CA');
+      const sum = (getExpenses() || [])
+        .filter(exp => exp.date === today)
+        .reduce((s, exp) => s + Number(exp.amount), 0);
+      setTotal(sum);
+    }
+    calc();
+    document.addEventListener('expensesUpdated', calc);
+    return () => document.removeEventListener('expensesUpdated', calc);
+  }, []);
+  const symbol = getCurrency();
+  return e(WidgetCard, null,
+    e('small', { className: 'today-label' }, 'Spent Today'),
+    e('div', { className: 'today-amount' }, symbol + total.toFixed(2))
+  );
+}
+
+function WidgetGrid() {
+  // For now only one widget but designed for dynamic widgets
+  return e('div', { className: 'widget-grid' },
+    e(SpentTodayWidget, null)
+  );
+}
+
+function TransactionsList({ items }) {
+  return e('ul', { className: 'transactions-list' },
+    items.map(item =>
+      e('li', { key: item.id },
+        `${item.date} - ${item.category} ${getCurrency()}${Number(item.amount).toFixed(2)}`
+      )
+    )
+  );
+}
+
+function TransactionsSection() {
+  const [showAll, setShowAll] = useState(false);
+  const [items, setItems] = useState([]);
+
+  useEffect(() => {
+    function load() {
+      const all = (getExpenses() || [])
+        .slice()
+        .sort((a, b) => new Date(b.date) - new Date(a.date));
+      const today = new Date().toLocaleDateString('en-CA');
+      setItems(showAll ? all : all.filter(i => i.date === today));
+    }
+    load();
+    document.addEventListener('expensesUpdated', load);
+    return () => document.removeEventListener('expensesUpdated', load);
+  }, [showAll]);
+
+  return e('div', { className: 'transactions-section' },
+    e('div', { className: 'transactions-header' },
+      e('h2', null, "Today's Categories"),
+      e('button', { className: 'view-all-btn', onClick: () => setShowAll(v => !v) },
+        showAll ? 'Close' : 'View All Transactions'
+      )
+    ),
+    e(TransactionsList, { items })
+  );
+}
+
+function App() {
+  return e(React.Fragment, null,
+    e(WidgetGrid, null),
+    e(TransactionsSection, null)
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('app')).render(e(App));

--- a/index.html
+++ b/index.html
@@ -19,11 +19,7 @@
       <div id="sidebar-content" class="sidebar-content"></div>
     </nav>
     <main>
-      <div class="today-summary">
-        <small class="today-label">Spent Today</small>
-        <div id="total" class="today-amount"></div>
-      </div>
-      <ul id="list"></ul>
+      <div id="app"></div>
     </main>
     <div class="fab-wrapper">
       <button id="fab" class="fab">+</button>
@@ -56,6 +52,9 @@
     </div>
   </div>
   <script src="script.js"></script>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="app.js"></script>
 
   <template id="tmpl-categories">
     <div class="sidebar-page">

--- a/script.js
+++ b/script.js
@@ -170,6 +170,7 @@ function showExpenses() {
       list.appendChild(li);
     });
   totalEl.textContent = `${symbol}${todayTotal.toFixed(2)}`;
+  document.dispatchEvent(new Event('expensesUpdated'));
 }
 
 function updateExpense(id, amount, category, note, date) {
@@ -182,12 +183,14 @@ function updateExpense(id, amount, category, note, date) {
   expenses[idx].date = date;
   localStorage.setItem('expenses', JSON.stringify(expenses));
   showExpenses();
+  document.dispatchEvent(new Event('expensesUpdated'));
 }
 
 function deleteExpense(id) {
   const expenses = getExpenses().filter(e => e.id !== id);
   localStorage.setItem('expenses', JSON.stringify(expenses));
   showExpenses();
+  document.dispatchEvent(new Event('expensesUpdated'));
 }
 
 function initEditItem(li, expense) {
@@ -289,6 +292,7 @@ function saveExpense(e) {
   localStorage.setItem('expenses', JSON.stringify(expenses));
   togglePopup(false);
   showExpenses();
+  document.dispatchEvent(new Event('expensesUpdated'));
 }
 
 function togglePopup(open) {

--- a/style.css
+++ b/style.css
@@ -540,3 +540,62 @@ input[type=number] {
   opacity: 1;
   transform: scale(1);
 }
+
+/* Masonry widget grid */
+.widget-grid {
+  column-count: 1;
+  column-gap: 1rem;
+  width: 100%;
+  max-width: 600px;
+}
+
+@media (min-width: 600px) {
+  .widget-grid {
+    column-count: 2;
+  }
+}
+
+.widget-card {
+  display: inline-block;
+  width: 100%;
+  background: #fff;
+  padding: 1rem;
+  border-radius: 12px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+  margin-bottom: 1rem;
+  break-inside: avoid;
+}
+
+.transactions-section {
+  width: 100%;
+  max-width: 600px;
+}
+
+.transactions-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.transactions-list {
+  list-style: none;
+  padding: 0;
+}
+
+.transactions-list li {
+  background: #fff;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+  margin-bottom: 0.5rem;
+}
+
+.view-all-btn {
+  background: transparent;
+  border: none;
+  color: var(--md-primary);
+  cursor: pointer;
+  font-size: 0.9rem;
+}


### PR DESCRIPTION
## Summary
- replace existing summary section with React root
- add React-based widget and transactions components
- update CSS with masonry grid styles
- dispatch `expensesUpdated` events from script.js to keep React in sync

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_687165693d608327998821c7cc18a838