### PR TITLE
Add widget settings and full-width summary

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
         </div>
       </div>
       <section id="transactions-section" class="transactions-section">
+        <button type="button" id="close-transactions" class="close-transactions" aria-label="Close">&times;</button>
         <div class="transactions-header">
           <h2 class="transactions-title">Today's Spends</h2>
           <button type="button" id="toggle-transactions" class="link-btn">View all Transactions</button>

--- a/index.html
+++ b/index.html
@@ -34,7 +34,6 @@
         </div>
       </div>
       <section id="transactions-section" class="transactions-section">
-        <button type="button" id="close-transactions" class="close-transactions" aria-label="Close">&times;</button>
         <div class="transactions-header">
           <h2 class="transactions-title">Today's Spends</h2>
           <button type="button" id="toggle-transactions" class="link-btn">View all Transactions</button>

--- a/index.html
+++ b/index.html
@@ -19,9 +19,19 @@
       <div id="sidebar-content" class="sidebar-content"></div>
     </nav>
     <main>
-      <div class="today-summary">
-        <small class="today-label">Spent Today</small>
-        <div id="total" class="today-amount"></div>
+      <div id="widget-row" class="widget-row">
+        <div class="summary-widget today-summary">
+          <small class="today-label">Spent Today</small>
+          <div id="total" class="today-amount"></div>
+        </div>
+        <div id="monthly-summary" class="summary-widget" hidden>
+          <small>Total This Month</small>
+          <div id="monthly-total" class="today-amount"></div>
+        </div>
+        <div id="budget-summary" class="summary-widget" hidden>
+          <small>Remaining Budget</small>
+          <div id="budget-remaining" class="today-amount"></div>
+        </div>
       </div>
       <ul id="list"></ul>
     </main>
@@ -76,6 +86,13 @@
             <div id="currency-options" class="options"></div>
           </div>
         </div>
+        <label for="budget-input">Monthly Budget</label>
+        <input type="number" id="budget-input" placeholder="0">
+        <fieldset class="widget-settings">
+          <legend>Home Widgets</legend>
+          <label><input type="checkbox" id="widget-monthly-setting"> Total monthly spends</label>
+          <label><input type="checkbox" id="widget-budget-setting"> Remaining budget</label>
+        </fieldset>
         <button type="submit" id="settings-save" class="button">Save <span id="save-icon" class="save-icon"></span></button>
       </form>
     </div>

--- a/index.html
+++ b/index.html
@@ -33,7 +33,13 @@
           <div id="budget-remaining" class="today-amount"></div>
         </div>
       </div>
-      <ul id="list"></ul>
+      <section id="transactions-section" class="transactions-section">
+        <div class="transactions-header">
+          <h2 class="transactions-title">Today's Spends</h2>
+          <button type="button" id="toggle-transactions" class="link-btn">View all Transactions</button>
+        </div>
+        <ul id="list"></ul>
+      </section>
     </main>
     <div class="fab-wrapper">
       <button id="fab" class="fab">+</button>

--- a/script.js
+++ b/script.js
@@ -564,14 +564,22 @@ function init() {
   const toggleBtn = document.getElementById('toggle-transactions');
   const txSection = document.getElementById('transactions-section');
   const txTitle = document.querySelector('.transactions-title');
-  if (toggleBtn && txSection && txTitle) {
-    toggleBtn.addEventListener('click', () => {
-      viewAllTransactions = !viewAllTransactions;
-      txSection.classList.toggle('fullscreen', viewAllTransactions);
-      toggleBtn.textContent = viewAllTransactions ? 'Close' : 'View all Transactions';
-      txTitle.textContent = viewAllTransactions ? 'All Transactions' : "Today's Spends";
-      showExpenses(viewAllTransactions);
-    });
+  const closeTx = document.getElementById('close-transactions');
+  function openTransactions() {
+    viewAllTransactions = true;
+    txSection.classList.add('fullscreen');
+    txTitle.textContent = 'All Transactions';
+    showExpenses(true);
+  }
+  function closeTransactions() {
+    viewAllTransactions = false;
+    txSection.classList.remove('fullscreen');
+    txTitle.textContent = "Today's Spends";
+    showExpenses(false);
+  }
+  if (toggleBtn && txSection && txTitle && closeTx) {
+    toggleBtn.addEventListener('click', openTransactions);
+    closeTx.addEventListener('click', closeTransactions);
   }
 
   const order = ['amount', 'category-btn', 'note', 'calendar-btn', 'save-btn'];

--- a/script.js
+++ b/script.js
@@ -65,6 +65,7 @@ function fitAmount(el) {
 let selectedDate = new Date();
 let currentCalMonth = new Date();
 let selectedCategory = 'Food';
+let viewAllTransactions = false;
 
 function resetForm() {
   const amount = document.getElementById('amount');
@@ -139,7 +140,7 @@ function toggleCalendar(forceOpen) {
   }
 }
 
-function showExpenses() {
+function showExpenses(showAll = false) {
   const list = document.getElementById('list');
   const totalEl = document.getElementById('total');
   const monthlyEl = document.getElementById('monthly-total');
@@ -169,6 +170,7 @@ function showExpenses() {
           monthTotal += e.amount;
         }
       }
+      if (!showAll && e.date !== today) return;
       const li = document.createElement('li');
       li.className = 'expense-item';
       li.dataset.id = e.id;
@@ -252,13 +254,13 @@ function updateExpense(id, amount, category, note, date) {
   expenses[idx].note = note;
   expenses[idx].date = date;
   localStorage.setItem('expenses', JSON.stringify(expenses));
-  showExpenses();
+  showExpenses(viewAllTransactions);
 }
 
 function deleteExpense(id) {
   const expenses = getExpenses().filter(e => e.id !== id);
   localStorage.setItem('expenses', JSON.stringify(expenses));
-  showExpenses();
+  showExpenses(viewAllTransactions);
 }
 
 function initEditItem(li, expense) {
@@ -359,7 +361,7 @@ function saveExpense(e) {
   expenses.push({ id: Date.now().toString(), amount, category: selectedCategory, note, date });
   localStorage.setItem('expenses', JSON.stringify(expenses));
   togglePopup(false);
-  showExpenses();
+  showExpenses(viewAllTransactions);
 }
 
 function togglePopup(open) {
@@ -474,7 +476,7 @@ function initSettings() {
         saveIcon.textContent = '';
       }, 1000);
     }
-    showExpenses();
+    showExpenses(viewAllTransactions);
     applyWidgetSettings();
   });
 }
@@ -518,7 +520,7 @@ function initSidebarNav() {
 }
 
 function init() {
-  showExpenses();
+  showExpenses(viewAllTransactions);
   applyWidgetSettings();
   const form = document.getElementById('expense-form');
   if (form) {
@@ -556,6 +558,19 @@ function init() {
       if (!catBtn.contains(e.target) && !menu.contains(e.target)) {
         menu.hidden = true;
       }
+    });
+  }
+
+  const toggleBtn = document.getElementById('toggle-transactions');
+  const txSection = document.getElementById('transactions-section');
+  const txTitle = document.querySelector('.transactions-title');
+  if (toggleBtn && txSection && txTitle) {
+    toggleBtn.addEventListener('click', () => {
+      viewAllTransactions = !viewAllTransactions;
+      txSection.classList.toggle('fullscreen', viewAllTransactions);
+      toggleBtn.textContent = viewAllTransactions ? 'Close' : 'View all Transactions';
+      txTitle.textContent = viewAllTransactions ? 'All Transactions' : "Today's Spends";
+      showExpenses(viewAllTransactions);
     });
   }
 

--- a/script.js
+++ b/script.js
@@ -81,6 +81,27 @@ function updateTransactionsPosition() {
   }
 }
 
+function animateFlip(el, first, last) {
+  const dx = first.left - last.left;
+  const dy = first.top - last.top;
+  const sx = first.width / last.width;
+  const sy = first.height / last.height;
+  el.style.transformOrigin = 'top left';
+  el.style.transition = 'transform 0.4s cubic-bezier(0.34,1.56,0.64,1)';
+  el.style.transform = `translate(${dx}px, ${dy}px) scale(${sx}, ${sy})`;
+  requestAnimationFrame(() => {
+    el.style.transform = 'none';
+  });
+  el.addEventListener(
+    'transitionend',
+    () => {
+      el.style.transition = '';
+      el.style.transform = '';
+    },
+    { once: true }
+  );
+}
+
 function resetForm() {
   const amount = document.getElementById('amount');
   const note = document.getElementById('note');
@@ -611,6 +632,7 @@ function init() {
 
 
   function openTransactions() {
+    const first = txSection.getBoundingClientRect();
     viewAllTransactions = true;
     txSection.classList.add('expanded');
     document.body.classList.add('no-scroll');
@@ -619,9 +641,12 @@ function init() {
     toggleBtn.innerHTML = '&times;';
     showExpenses(true);
     updateTransactionsPosition();
+    const last = txSection.getBoundingClientRect();
+    animateFlip(txSection, first, last);
   }
 
   function closeTransactions() {
+    const first = txSection.getBoundingClientRect();
     viewAllTransactions = false;
     txSection.classList.remove('expanded');
     document.body.classList.remove('no-scroll');
@@ -630,6 +655,8 @@ function init() {
     toggleBtn.textContent = 'View all Transactions';
     showExpenses(false);
     updateTransactionsPosition();
+    const last = txSection.getBoundingClientRect();
+    animateFlip(txSection, first, last);
   }
 
   if (toggleBtn && txSection && txTitle) {

--- a/script.js
+++ b/script.js
@@ -568,18 +568,25 @@ function init() {
   function openTransactions() {
     viewAllTransactions = true;
     txSection.classList.add('expanded');
+    document.body.classList.add('no-scroll');
     txTitle.textContent = 'All Transactions';
     showExpenses(true);
   }
   function closeTransactions() {
     viewAllTransactions = false;
     txSection.classList.remove('expanded');
+    document.body.classList.remove('no-scroll');
     txTitle.textContent = "Today's Spends";
     showExpenses(false);
   }
   if (toggleBtn && txSection && txTitle && closeTx) {
     toggleBtn.addEventListener('click', openTransactions);
     closeTx.addEventListener('click', closeTransactions);
+    document.addEventListener('keydown', e => {
+      if (e.key === 'Escape' && txSection.classList.contains('expanded')) {
+        closeTransactions();
+      }
+    });
   }
 
   const order = ['amount', 'category-btn', 'note', 'calendar-btn', 'save-btn'];

--- a/script.js
+++ b/script.js
@@ -37,6 +37,31 @@ function getSymbolFromCode(code) {
   }
 }
 
+function formatAmountParts(val) {
+  const str = val.toFixed(2);
+  const [intPart, decPart] = str.split('.');
+  return { intPart, decPart };
+}
+
+function setAmount(element, amount) {
+  if (!element) return;
+  const symbol = getCurrency();
+  const { intPart, decPart } = formatAmountParts(amount);
+  element.innerHTML = `${symbol}<span class="amount-int">${intPart}</span><span class="amount-dec">.${decPart}</span>`;
+  fitAmount(element);
+}
+
+function fitAmount(el) {
+  if (!el || !el.parentElement) return;
+  el.style.fontSize = '';
+  let size = parseFloat(getComputedStyle(el).fontSize);
+  const min = 16;
+  while (el.scrollWidth > el.parentElement.clientWidth && size > min) {
+    size -= 1;
+    el.style.fontSize = size + 'px';
+  }
+}
+
 let selectedDate = new Date();
 let currentCalMonth = new Date();
 let selectedCategory = 'Food';
@@ -196,11 +221,11 @@ function showExpenses() {
 
       list.appendChild(li);
     });
-  totalEl.textContent = `${symbol}${todayTotal.toFixed(2)}`;
-  if (monthlyEl) monthlyEl.textContent = `${symbol}${monthTotal.toFixed(2)}`;
+  setAmount(totalEl, todayTotal);
+  if (monthlyEl) setAmount(monthlyEl, monthTotal);
   if (budgetEl) {
     const remaining = getBudgetAmount() - monthTotal;
-    budgetEl.textContent = `${symbol}${remaining.toFixed(2)}`;
+    setAmount(budgetEl, remaining);
   }
 }
 
@@ -210,6 +235,12 @@ function applyWidgetSettings() {
   const budgetSummary = document.getElementById('budget-summary');
   if (monthlySummary) monthlySummary.hidden = !widgets.includes('monthly');
   if (budgetSummary) budgetSummary.hidden = !widgets.includes('budget');
+  if (monthlySummary && !monthlySummary.hidden) {
+    fitAmount(monthlySummary.querySelector('.today-amount'));
+  }
+  if (budgetSummary && !budgetSummary.hidden) {
+    fitAmount(budgetSummary.querySelector('.today-amount'));
+  }
 }
 
 function updateExpense(id, amount, category, note, date) {

--- a/script.js
+++ b/script.js
@@ -567,13 +567,13 @@ function init() {
   const closeTx = document.getElementById('close-transactions');
   function openTransactions() {
     viewAllTransactions = true;
-    txSection.classList.add('fullscreen');
+    txSection.classList.add('expanded');
     txTitle.textContent = 'All Transactions';
     showExpenses(true);
   }
   function closeTransactions() {
     viewAllTransactions = false;
-    txSection.classList.remove('fullscreen');
+    txSection.classList.remove('expanded');
     txTitle.textContent = "Today's Spends";
     showExpenses(false);
   }

--- a/script.js
+++ b/script.js
@@ -81,22 +81,30 @@ function updateTransactionsPosition() {
   }
 }
 
-function animateFlip(el, first, last) {
-  const dx = first.left - last.left;
-  const dy = first.top - last.top;
-  const sx = first.width / last.width;
-  const sy = first.height / last.height;
-  el.style.transformOrigin = 'top left';
-  el.style.transition = 'transform 0.4s cubic-bezier(0.34,1.56,0.64,1)';
-  el.style.transform = `translate(${dx}px, ${dy}px) scale(${sx}, ${sy})`;
+function animateBounds(el, first, last) {
+  el.style.position = 'fixed';
+  el.style.top = first.top + 'px';
+  el.style.left = first.left + 'px';
+  el.style.width = first.width + 'px';
+  el.style.height = first.height + 'px';
+  el.style.margin = '0';
+  el.style.transition = 'all 0.4s cubic-bezier(0.34,1.56,0.64,1)';
   requestAnimationFrame(() => {
-    el.style.transform = 'none';
+    el.style.top = last.top + 'px';
+    el.style.left = last.left + 'px';
+    el.style.width = last.width + 'px';
+    el.style.height = last.height + 'px';
   });
   el.addEventListener(
     'transitionend',
     () => {
       el.style.transition = '';
-      el.style.transform = '';
+      el.style.position = '';
+      el.style.top = '';
+      el.style.left = '';
+      el.style.width = '';
+      el.style.height = '';
+      el.style.margin = '';
     },
     { once: true }
   );
@@ -633,30 +641,50 @@ function init() {
 
   function openTransactions() {
     const first = txSection.getBoundingClientRect();
-    viewAllTransactions = true;
     txSection.classList.add('expanded');
+    updateTransactionsPosition();
+    const last = txSection.getBoundingClientRect();
+    txSection.classList.remove('expanded');
+    updateTransactionsPosition();
+    viewAllTransactions = true;
     document.body.classList.add('no-scroll');
     txTitle.textContent = 'All Transactions';
     toggleBtn.classList.add('close');
     toggleBtn.innerHTML = '&times;';
     showExpenses(true);
-    updateTransactionsPosition();
-    const last = txSection.getBoundingClientRect();
-    animateFlip(txSection, first, last);
+    animateBounds(txSection, first, last);
+    txSection.addEventListener(
+      'transitionend',
+      () => {
+        txSection.classList.add('expanded');
+        updateTransactionsPosition();
+      },
+      { once: true }
+    );
   }
 
   function closeTransactions() {
     const first = txSection.getBoundingClientRect();
-    viewAllTransactions = false;
     txSection.classList.remove('expanded');
+    updateTransactionsPosition();
+    const last = txSection.getBoundingClientRect();
+    txSection.classList.add('expanded');
+    updateTransactionsPosition();
+    viewAllTransactions = false;
     document.body.classList.remove('no-scroll');
     txTitle.textContent = "Today's Spends";
     toggleBtn.classList.remove('close');
     toggleBtn.textContent = 'View all Transactions';
     showExpenses(false);
-    updateTransactionsPosition();
-    const last = txSection.getBoundingClientRect();
-    animateFlip(txSection, first, last);
+    animateBounds(txSection, first, last);
+    txSection.addEventListener(
+      'transitionend',
+      () => {
+        txSection.classList.remove('expanded');
+        updateTransactionsPosition();
+      },
+      { once: true }
+    );
   }
 
   if (toggleBtn && txSection && txTitle) {

--- a/style.css
+++ b/style.css
@@ -18,6 +18,10 @@ body {
   color: var(--md-on-surface);
 }
 
+.no-scroll {
+  overflow: hidden;
+}
+
 .layout {
   display: flex;
   min-height: 100vh;
@@ -155,8 +159,7 @@ main > * {
   padding: 1rem;
   margin-bottom: 1rem;
   overflow-y: hidden;
-  transition: width 0.4s cubic-bezier(0.34, 1.56, 0.64, 1),
-              max-height 0.4s ease;
+  transition: all 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
   max-height: 400px;
   display: flex;
   flex-direction: column;
@@ -167,8 +170,17 @@ main > * {
 }
 
 .transactions-section.expanded {
-  width: 100%;
-  max-height: 2000px;
+  position: fixed;
+  top: 1rem;
+  left: 1rem;
+  right: 1rem;
+  bottom: 1rem;
+  width: auto;
+  height: auto;
+  max-height: calc(100vh - 2rem);
+  margin: 0;
+  overflow-y: auto;
+  z-index: 1000;
 }
 
 .transactions-header {
@@ -179,13 +191,14 @@ main > * {
 }
 
 .link-btn {
-  background: none;
+  background: var(--md-primary);
+  color: var(--md-on-primary);
   border: none;
-  color: var(--md-primary);
+  padding: 0.25rem 0.75rem;
+  border-radius: 8px;
   cursor: pointer;
-  text-decoration: underline;
-  padding: 0;
-  font: inherit;
+  font-size: 0.875rem;
+  text-decoration: none;
 }
 
 .close-transactions {

--- a/style.css
+++ b/style.css
@@ -139,9 +139,11 @@ main > * {
 .widget-row {
   display: flex;
   gap: 1rem;
+  padding: 0 1rem;
   margin: 2rem 0 1rem;
   width: 100%;
   box-sizing: border-box;
+  justify-content: space-between;
 }
 
 .summary-widget {

--- a/style.css
+++ b/style.css
@@ -201,21 +201,14 @@ main > * {
   text-decoration: none;
 }
 
-.close-transactions {
-  position: absolute;
-  top: 6px;
-  right: 6px;
-  background: transparent;
-  border: none;
+.link-btn.close {
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   font-size: 1.25rem;
-  line-height: 1;
-  color: var(--md-primary);
-  cursor: pointer;
-  display: none;
-}
-
-.transactions-section.expanded .close-transactions {
-  display: block;
 }
 
 .summary-widget {
@@ -367,6 +360,24 @@ li.expanded .item-details {
 .item-details .calendar-btn {
   background: var(--md-on-primary);
   color: var(--md-primary);
+}
+
+.date-group {
+  border: 1px solid var(--md-primary);
+  border-radius: 12px;
+  padding: 0.5rem;
+  margin-bottom: 0.75rem;
+  background: var(--md-surface);
+}
+
+.date-group > ul {
+  list-style: none;
+  padding: 0;
+  margin: 0.5rem 0 0;
+}
+
+.date-header {
+  font-weight: bold;
 }
 
 .fab-wrapper {

--- a/style.css
+++ b/style.css
@@ -3,7 +3,7 @@
   --md-on-primary: #ffffff;
   --md-surface: #fef7ff;
   --md-on-surface: #1c1b1f;
-  --md-surface-variant: #e7e0ec;
+  --md-surface-variant: #d4c8e0;
   --md-sidebar-light: #faf7ff;
 }
 
@@ -166,6 +166,12 @@ main > * {
   font-weight: bold;
   margin: 0.25rem 0 1.5rem;
   overflow-wrap: anywhere;
+  line-height: 1;
+  white-space: nowrap;
+  display: inline-block;
+}
+.amount-dec {
+  font-size: 0.5em;
 }
 
 .button {

--- a/style.css
+++ b/style.css
@@ -166,7 +166,6 @@ main > * {
   width: 50%;
   max-width: none;
   position: relative;
-  transform-origin: top left;
 }
 
 .transactions-section.expanded {

--- a/style.css
+++ b/style.css
@@ -155,25 +155,20 @@ main > * {
   padding: 1rem;
   margin-bottom: 1rem;
   overflow-y: hidden;
-  transition: all 0.4s ease;
+  transition: width 0.4s cubic-bezier(0.34, 1.56, 0.64, 1),
+              max-height 0.4s ease;
   max-height: 400px;
   display: flex;
   flex-direction: column;
   align-self: flex-start;
-  width: 100%;
+  width: 50%;
   max-width: none;
   position: relative;
 }
 
-.transactions-section.fullscreen {
-  position: fixed;
-  inset: 0;
-  margin: 0;
-  border-radius: 0;
-  background: var(--md-surface);
-  max-height: calc(100vh - 2rem);
-  z-index: 10;
-  overflow-y: auto;
+.transactions-section.expanded {
+  width: 100%;
+  max-height: 2000px;
 }
 
 .transactions-header {
@@ -206,7 +201,7 @@ main > * {
   display: none;
 }
 
-.transactions-section.fullscreen .close-transactions {
+.transactions-section.expanded .close-transactions {
   display: block;
 }
 

--- a/style.css
+++ b/style.css
@@ -155,10 +155,14 @@ main > * {
   padding: 1rem;
   margin-bottom: 1rem;
   overflow-y: hidden;
-  transition: max-height 0.4s ease;
+  transition: all 0.4s ease;
   max-height: 400px;
   display: flex;
   flex-direction: column;
+  align-self: flex-start;
+  width: 100%;
+  max-width: none;
+  position: relative;
 }
 
 .transactions-section.fullscreen {
@@ -167,7 +171,7 @@ main > * {
   margin: 0;
   border-radius: 0;
   background: var(--md-surface);
-  max-height: none;
+  max-height: calc(100vh - 2rem);
   z-index: 10;
   overflow-y: auto;
 }
@@ -187,6 +191,23 @@ main > * {
   text-decoration: underline;
   padding: 0;
   font: inherit;
+}
+
+.close-transactions {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  background: transparent;
+  border: none;
+  font-size: 1.25rem;
+  line-height: 1;
+  color: var(--md-primary);
+  cursor: pointer;
+  display: none;
+}
+
+.transactions-section.fullscreen .close-transactions {
+  display: block;
 }
 
 .summary-widget {

--- a/style.css
+++ b/style.css
@@ -155,6 +155,14 @@ main > * {
   background: var(--md-surface-variant);
   border: 1px solid var(--md-primary);
   border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.summary-widget small {
+  display: block;
+  margin-bottom: 0.25rem;
 }
 
 .today-summary {

--- a/style.css
+++ b/style.css
@@ -159,7 +159,6 @@ main > * {
   padding: 1rem;
   margin-bottom: 1rem;
   overflow-y: hidden;
-  transition: all 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
   max-height: 400px;
   display: flex;
   flex-direction: column;
@@ -167,6 +166,7 @@ main > * {
   width: 50%;
   max-width: none;
   position: relative;
+  transform-origin: top left;
 }
 
 .transactions-section.expanded {
@@ -175,6 +175,7 @@ main > * {
   left: 1rem;
   right: 1rem;
   bottom: 1rem;
+  border: 1px solid var(--md-primary);
   width: auto;
   height: auto;
   max-height: calc(100vh - 2rem);

--- a/style.css
+++ b/style.css
@@ -139,11 +139,13 @@ main > * {
 .widget-row {
   display: flex;
   gap: 1rem;
-  padding: 0 1rem;
   margin: 2rem 0 1rem;
   width: 100%;
+  max-width: none;
   box-sizing: border-box;
   justify-content: space-between;
+  align-self: stretch;
+  padding: 0;
 }
 
 .summary-widget {

--- a/style.css
+++ b/style.css
@@ -136,11 +136,25 @@ main > * {
   margin: 1rem 0;
 }
 
-.today-summary {
+.widget-row {
+  display: flex;
+  gap: 1rem;
+  margin: 2rem 0 1rem;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.summary-widget {
+  flex: 1;
   text-align: center;
-  margin: 2rem auto 1rem;
-  min-width: 33%;
-  width: fit-content;
+  padding: 1rem;
+  background: var(--md-surface-variant);
+  border: 1px solid var(--md-primary);
+  border-radius: 12px;
+}
+
+.today-summary {
+  /* inherits summary-widget */
 }
 
 .today-amount {
@@ -503,6 +517,18 @@ input[type=number] {
   border: 1px solid var(--md-surface-variant);
   border-radius: 6px;
   margin-bottom: 0.5rem;
+}
+
+.widget-settings {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.widget-settings label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .currency-option {

--- a/style.css
+++ b/style.css
@@ -148,6 +148,47 @@ main > * {
   padding: 0;
 }
 
+.transactions-section {
+  background: var(--md-surface-variant);
+  border: 1px solid var(--md-primary);
+  border-radius: 12px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  overflow-y: hidden;
+  transition: max-height 0.4s ease;
+  max-height: 400px;
+  display: flex;
+  flex-direction: column;
+}
+
+.transactions-section.fullscreen {
+  position: fixed;
+  inset: 0;
+  margin: 0;
+  border-radius: 0;
+  background: var(--md-surface);
+  max-height: none;
+  z-index: 10;
+  overflow-y: auto;
+}
+
+.transactions-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.link-btn {
+  background: none;
+  border: none;
+  color: var(--md-primary);
+  cursor: pointer;
+  text-decoration: underline;
+  padding: 0;
+  font: inherit;
+}
+
 .summary-widget {
   flex: 1;
   text-align: center;
@@ -218,14 +259,15 @@ ul {
 
 #list {
   width: 100%;
-  max-width: 600px;
+  max-width: none;
   margin-left: 0;
-  align-self: flex-start;
+  align-self: stretch;
 }
 
 li {
   display: block;
-  background: #fff;
+  background: var(--md-surface);
+  border: 1px solid var(--md-primary);
   padding: 0.75rem 1rem;
   border-radius: 12px;
   box-shadow: 0 1px 3px rgba(0,0,0,0.1);


### PR DESCRIPTION
## Summary
- expand the top summary area to full width
- allow optional monthly and budget widgets via settings
- style widget row and widget settings
- compute monthly totals and remaining budget

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68716b12f8d08327856b953b9d0c8cf3